### PR TITLE
feat: add Vercel AI Gateway to README (issue #339)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ You can start contributing by adding the following:
 | [Mubert](https://mubert.com/) | [Link](https://mubert2.docs.apiary.io/#) | Y | Generates personalized soundtracks. |
 | [SharpAPI](https://sharpapi.com/) | [Link](https://sharpapi.com/documentation) | Y | Generative AI APIs for some use cases in E-Commerce, Marketing, Content Management, HR Tech, Travel, etc.|
 | [Pollinations.AI](https://pollinations.ai/) | [Link](https://github.com/pollinations/pollinations/blob/master/APIDOCS.md) | N | Pollinations.AI provides free, no-signup APIs for text, image, and audio generation with no API keys required. |
+| [Vercel AI Gateway](https://vercel.com/ai-gateway) | [Link](https://vercel.com/docs/ai-gateway) | Y | Unified API endpoint across multiple AI model providers; supports model switching, fallback, spend monitoring, and OpenAI-compatible endpoints. |
+
 
 ## GenAI API Integration Articles/Tutorials
 


### PR DESCRIPTION
What
-----
Added Vercel AI Gateway to the Text Generation section in README.

Details
-------
| [Vercel AI Gateway](https://vercel.com/ai-gateway) | [Link](https://vercel.com/docs/ai-gateway) | Y (API Key / OIDC) | Unified API endpoint across AI providers; supports model switching, fallback, spend monitoring, and OpenAI-compatible endpoints. |

Why
---
Helps developers integrate and switch between AI providers while monitoring costs.

Notes
-----
Closes #339
