### PR TITLE
Add Glio - Unified API for 90+ AI media models

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can start contributing by adding the following:
 | [Pollinations.AI](https://pollinations.ai/) | [Link](https://github.com/pollinations/pollinations/blob/master/APIDOCS.md) | N | Pollinations.AI provides free, no-signup APIs for text, image, and audio generation with no API keys required. |
 | [Vercel AI Gateway](https://vercel.com/ai-gateway) | [Link](https://vercel.com/docs/ai-gateway) | Y | Unified API endpoint across multiple AI model providers; supports model switching, fallback, spend monitoring, and OpenAI-compatible endpoints. |
 | [Vedika](https://vedika.io) | [Link](https://vedika.io/docs) | Y | GenAI-powered Vedic astrology API. Natural language queries for birth charts, compatibility analysis, and predictions |
-| [Glio](https://glio.io/) | [Link](https://glio.io/docs/api/) | Y | Unified API for the most cost-effective access to 50+ SOTA models. Kling, NanoBanana, Sora2, Veo3, Suno, ElevenLabs and more. Pay-per-use, no subscriptions. |
+| [Glio](https://glio.io/) | [Link](https://glio.io/docs/api/) | Y | Unified API for the most cost-effective access to 50+ SOTA models. Kling, NanoBanana, Sora2, Veo3, Suno, ElevenLabs and more |
 
 
 ## GenAI API Integration Articles/Tutorials


### PR DESCRIPTION
## Summary

Adding [Glio](https://glio.io/) to the GenAI APIs list.

**Glio** provides a unified API for AI media generation across 90+ models:
- **Video**: Kling, Sora, Runway, Luma, Veo3, Hailuo
- **Image**: Midjourney, FLUX, Ideogram, Recraft
- **Audio**: Suno, ElevenLabs (TTS/STT/SFX)

### Why it fits this list
- Single endpoint for multiple AI providers (similar to AI/ML API, Vercel AI Gateway)
- Pay-per-use pricing, no subscriptions
- Full OpenAPI spec + llms.txt for AI agent integration
- Active API with documentation

### Links
- Homepage: https://glio.io/
- API Docs: https://api.glio.io/docs/api/
- OpenAPI Spec: https://api.glio.io/openapi.json
- llms.txt: https://api.glio.io/llms.txt