### PR TITLE
Add Taskade to GenAI APIs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can start contributing by adding the following:
 | [Pollinations.AI](https://pollinations.ai/) | [Link](https://github.com/pollinations/pollinations/blob/master/APIDOCS.md) | N | Pollinations.AI provides free, no-signup APIs for text, image, and audio generation with no API keys required. |
 | [Vercel AI Gateway](https://vercel.com/ai-gateway) | [Link](https://vercel.com/docs/ai-gateway) | Y | Unified API endpoint across multiple AI model providers; supports model switching, fallback, spend monitoring, and OpenAI-compatible endpoints. |
 | [Vedika](https://vedika.io) | [Link](https://vedika.io/docs) | Y | GenAI-powered Vedic astrology API. Natural language queries for birth charts, compatibility analysis, and predictions |
+| [Taskade](https://taskade.com/) | [Link](https://developers.taskade.com) | Y | Taskade offers APIs to build AI-native workspace apps, deploy autonomous AI agents, and automate workflows with 100+ integrations. |
 
 
 ## GenAI API Integration Articles/Tutorials


### PR DESCRIPTION
## Summary

Adding [Taskade](https://taskade.com/) to the GenAI APIs table.

Taskade (YC S19) provides a developer API ([developers.taskade.com](https://developers.taskade.com)) for building AI-native workspace apps, deploying autonomous AI agents, and automating workflows with 100+ integrations.

- **Project Homepage:** https://taskade.com
- **API Docs:** https://developers.taskade.com
- **Requires Auth Token:** Yes
- **GitHub:** https://github.com/taskade

The entry follows the existing table format.