### PR TITLE
Add Agent LLM Router to GenAI APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can start contributing by adding the following:
 | [Pollinations.AI](https://pollinations.ai/) | [Link](https://github.com/pollinations/pollinations/blob/master/APIDOCS.md) | N | Pollinations.AI provides free, no-signup APIs for text, image, and audio generation with no API keys required. |
 | [Vercel AI Gateway](https://vercel.com/ai-gateway) | [Link](https://vercel.com/docs/ai-gateway) | Y | Unified API endpoint across multiple AI model providers; supports model switching, fallback, spend monitoring, and OpenAI-compatible endpoints. |
 | [Vedika](https://vedika.io) | [Link](https://vedika.io/docs) | Y | GenAI-powered Vedic astrology API. Natural language queries for birth charts, compatibility analysis, and predictions |
+| [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | N | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYO keys, response caching, auto retries. 24+ models. |
 
 
 ## GenAI API Integration Articles/Tutorials


### PR DESCRIPTION
## What

Adding **Agent LLM Router** to the GenAI APIs table.

| Field | Value |
|-------|-------|
| **Name** | Agent LLM Router |
| **Homepage** | https://api-catalog-three.vercel.app/blog/free-llm-api |
| **API Docs** | https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs |
| **Requires Auth** | N (BYO keys — bring your own provider API keys) |
| **Description** | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYO keys, response caching, auto retries. 24+ models. |

## Why

Developers building AI agents or apps often need to switch between LLM providers (for cost, latency, or model capability reasons). Agent LLM Router provides a single OpenAI-compatible endpoint that proxies to 6+ providers and 24+ models — no vendor lock-in, with built-in caching and retries.

Closes #354