### PR TITLE
Add BGPT to GenAI APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can start contributing by adding the following:
 | [Pollinations.AI](https://pollinations.ai/) | [Link](https://github.com/pollinations/pollinations/blob/master/APIDOCS.md) | N | Pollinations.AI provides free, no-signup APIs for text, image, and audio generation with no API keys required. |
 | [Vercel AI Gateway](https://vercel.com/ai-gateway) | [Link](https://vercel.com/docs/ai-gateway) | Y | Unified API endpoint across multiple AI model providers; supports model switching, fallback, spend monitoring, and OpenAI-compatible endpoints. |
 | [Vedika](https://vedika.io) | [Link](https://vedika.io/docs) | Y | GenAI-powered Vedic astrology API. Natural language queries for birth charts, compatibility analysis, and predictions |
+| [BGPT](https://bgpt.pro) | [Link](https://github.com/connerlambden/bgpt-mcp) | Y | MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies. |
 
 
 ## GenAI API Integration Articles/Tutorials


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — remote MCP server for searching scientific papers and returning structured experimental data (methods, results, quality scores, sample sizes) extracted from full-text studies.

- SSE + Streamable HTTP endpoints
- Tool: `search_papers`
- npm: `npx bgpt-mcp`