### PR TITLE
Add AceTagGen Suno Scorer — free API for scoring Suno AI prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can start contributing by adding the following:
 | [Prompeteer.ai](https://prompeteer.ai) | [Link](https://prompeteer.ai/connect) | REST API to generate, score, and optimize AI prompts for 140+ platforms. Features Prompt Score quality analysis across 16 dimensions and PromptDrive auto-save cloud library |
 | [Arch Tools](https://archtools.dev/) | [Link](https://archtools.dev/docs) | The first x402 API hub — 58+ AI tools for search, scraping, analysis, and generation with native Coinbase x402 crypto payments on 15+ chains. MCP compatible |
 | [BGPT](https://bgpt.pro) | [Link](https://github.com/connerlambden/bgpt-mcp) | MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies |
+| [AceTagGen Suno Scorer](https://acetaggen.com/tools/prompt-scorer) | [Link](https://acetaggen.com/api/suno-score) | Free CORS-enabled REST API that scores Suno AI music prompts on a 100-point scale across 4 metrics (length, tag collisions, specificity, density). No auth. Open-source JS/TS library at [shaizadok92/suno-prompt-scorer](https://github.com/shaizadok92/suno-prompt-scorer) |
 
 ## GenAI API Integration Articles/Tutorials
 


### PR DESCRIPTION
Adding [AceTagGen Suno Scorer](https://acetaggen.com/tools/prompt-scorer) to Other AI Tools section.

**What the API does:**
- `GET /api/suno-score?prompt=your+prompt` — returns a 100-point score for Suno AI music prompts
- CORS-enabled, no auth, no rate-limiting (yet)
- Returns breakdown across 4 metrics: length, tag collisions, specificity, density

**Why it fits this list:**
Developers building tools on top of Suno AI have no programmatic way to validate prompts before users burn credits. This API fills that gap. It's also accompanied by an [open-source JS/TS library](https://github.com/shaizadok92/suno-prompt-scorer) (MIT-licensed, zero dependencies).

The existing section has tools like Prompeteer.ai (prompt scoring for 140+ platforms) — AceTagGen fills the Suno-specific niche.

**Example response:**
```json
{
  "prompt": "dark trap, 808 bass, triplet hi-hats",
  "total": 94,
  "breakdown": [
    {"label":"length","pct":100,"status":"good","message":"35 characters — within Suno's 200-char Style limit."},
    {"label":"collisions","pct":100,"status":"good","message":"No known colliding tag pairs detected."},
    {"label":"specificity","pct":100,"status":"good","message":"3 production tags + 0 mood tags — good balance."},
    {"label":"density","pct":60,"status":"warn","message":"5 words — room for more density."}
  ]
}
```

Thanks for maintaining this list — happy to adjust wording.