### PR TITLE
Add FuturMix to AI Providers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
+| [FuturMix](https://futurmix.ai/) | [Link](https://futurmix.ai/docs) | Unified AI gateway with 22+ models (Claude, GPT, Gemini) via OpenAI-compatible API. 99.99% SLA, single API key, 20-30% cheaper than alternatives |
 
 ## Other AI Tools
 


### PR DESCRIPTION
## Add FuturMix

Adding [FuturMix](https://futurmix.ai) to the AI Platform\/Aggregator section.

FuturMix is an enterprise AI agent platform providing OpenAI-compatible access to 22+ models (Claude, GPT, Gemini) .

- **Website**: https://futurmix.ai
- **Docs**: https://futurmix.ai/docs
- **Models**: 22+ (Anthropic, OpenAI, Google families)
- **SLA**: 99.99%
- **Compatibility**: OpenAI SDK compatible