### PR TITLE
Add peyeeye to Other AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can start contributing by adding the following:
 | [Prompeteer.ai](https://prompeteer.ai) | [Link](https://prompeteer.ai/connect) | REST API to generate, score, and optimize AI prompts for 140+ platforms. Features Prompt Score quality analysis across 16 dimensions and PromptDrive auto-save cloud library |
 | [Arch Tools](https://archtools.dev/) | [Link](https://archtools.dev/docs) | The first x402 API hub — 58+ AI tools for search, scraping, analysis, and generation with native Coinbase x402 crypto payments on 15+ chains. MCP compatible |
 | [BGPT](https://bgpt.pro) | [Link](https://github.com/connerlambden/bgpt-mcp) | MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies |
+| [peyeeye](https://peyeeye.ai) | [Link](https://peyeeye.ai/docs) | PII redaction and rehydration API for LLM prompts — strips emails, payment data, secrets, and 60+ entity types before the model sees them, then puts originals back in the response. Stateful sessions or stateless AEAD-sealed blobs |
 
 ## GenAI API Integration Articles/Tutorials
 


### PR DESCRIPTION
Adds [peyeeye](https://peyeeye.ai) to the Other AI Tools section.

peyeeye is a PII redaction and rehydration API for LLM prompts. It strips emails, payment data, secrets, government IDs, and 60+ entity types from prompts before they reach the model, then rehydrates originals into the response. Custom entities for domain-specific identifiers are first-class. Two deployment modes — stateful sessions or stateless AEAD-sealed rehydration keys for zero-retention setups.

Ships with Python + TypeScript SDKs and drop-in middleware for the Vercel AI SDK, LangChain, LangChain.js, and LiteLLM.

**Disclosure:** I'm the author/maintainer of peyeeye. Happy to adjust wording/placement.