### PR TITLE
Add WanAPIs to AI Gateway/Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
+| [WanAPIs](https://wanapis.com/) | [Link](https://wanapis.com/docs) | OpenAI-compatible AI API gateway for GPT, Claude, Gemini, DeepSeek, image, video, and audio models. Includes a model marketplace, usage logs, quota controls, multi-channel routing, and failover |
 
 ## Other AI Tools
 


### PR DESCRIPTION
Closes #387\n\nAdds WanAPIs to the AI Gateway/Aggregator section.\n\nWanAPIs is an OpenAI-compatible AI API gateway for GPT, Claude, Gemini, DeepSeek, image, video, and audio models. It includes a model marketplace, usage logs, quota controls, multi-channel routing, and failover.