### PR TITLE
Add AI Model Gateway to AI Gateway/Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You can start contributing by adding the following:
 
 | Project Homepage    | Docs Link  | Description (2 lines max)  |
 |:-----------|:------|:-------------|
+| [AI Model Gateway](https://ssc-studio.github.io/Ai-Model-Gateway/) | [Link](https://github.com/SSC-STUDIO/Ai-Model-Gateway#start-here) | Self-hosted LLM operations gateway for OpenAI-compatible routing, provider fallback, telemetry, benchmarking, config publishing, updates, and rollback. Bring your own upstream providers. |
 | [Vercel AI Gateway](https://vercel.com/ai-gateway) | [Link](https://vercel.com/docs/ai-gateway) | Unified API endpoint across multiple AI model providers; supports model switching, fallback, spend monitoring, and OpenAI-compatible endpoints |
 | [OmniRoute](https://github.com/diegosouzapw/OmniRoute) | [Link](https://github.com/diegosouzapw/OmniRoute) | Self-hostable AI gateway with 4-tier cascading fallback and multi-provider load balancing. Supports 200+ models across OpenAI, Anthropic, Google, and local providers via OpenAI-compatible API |
 | [Glio](https://glio.io/) | [Link](https://glio.io/docs/api/) | Unified API for the most cost-effective access to 50+ SOTA models. Kling, NanoBanana, Sora2, Veo3, Suno, ElevenLabs and more |


### PR DESCRIPTION
Closes #391

Adds AI Model Gateway to the AI Gateway/Aggregator section.

Disclosure: I maintain / am promoting this project from the SSC-STUDIO account, so this is a self-submission.

## Why it fits

AI Model Gateway is a self-hosted LLM operations gateway for OpenAI-compatible routing, provider fallback, telemetry, benchmarking, config publishing, update workflows, and rollback. It requires users to bring their own upstream providers.

## Checks

- `git diff --check`
- Checked that the README contains exactly one AI Model Gateway entry.
- Checked the AI Gateway/Aggregator table keeps three columns.
## Client integration evidence

- Client integration guide: https://github.com/SSC-STUDIO/Ai-Model-Gateway/blob/main/docs/client-integrations.md
- Shows how Codex, Claude Code, OpenClaw, generic OpenAI-compatible SDK clients, Anthropic-style clients, and curl smoke tests can point at the gateway.
- This is client-side setup evidence only; it does not claim every downstream tool feature is certified.
## Adoption checklist evidence

- Adoption checklist: https://ssc-studio.github.io/Ai-Model-Gateway/llm-gateway-adoption-checklist.html
- Covers fit, install paths, client compatibility, provider fallback, config publish, rollback, quality evidence, and security for maintainers who want a short evaluation path.