### PR TITLE
Add FerryAPI to AI gateway aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ You can start contributing by adding the following:
 | [EvoLink](https://evolink.ai/) | [Link](https://evolink.ai/docs) | Unified AI API gateway for 40+ models including video generation (Seedance 2.0, Sora 2, Veo 3.1), image generation, LLMs, and AI music |
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
+| [FerryAPI](https://www.ferryapi.com/) | [Link](https://www.ferryapi.com/docs/openai-compatible-api) | Low-cost OpenAI-compatible AI API gateway for routing AI SaaS and developer-tool traffic across models with usage visibility, quotas, and prepaid cost control. |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
 
 ## Other AI Tools


### PR DESCRIPTION
Adds FerryAPI to the AI Gateway/Aggregator section.

Why it fits:
- OpenAI-compatible API gateway for AI SaaS and developer-tool workloads
- Focuses on cost control, usage visibility, quotas, and routing across models
- Includes homepage and docs links in the existing table format

Disclosure: I work on FerryAPI.