### PR TITLE
Add cv.cm to GenAI APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You can start contributing by adding the following:
 | [SharpAPI](https://sharpapi.com/) | [Link](https://sharpapi.com/documentation) | Y | Generative AI APIs for some use cases in E-Commerce, Marketing, Content Management, HR Tech, Travel, etc.|
 | [Pollinations.AI](https://pollinations.ai/) | [Link](https://github.com/pollinations/pollinations/blob/master/APIDOCS.md) | N | Pollinations.AI provides free, no-signup APIs for text, image, and audio generation with no API keys required. |
 | [Vedika](https://vedika.io) | [Link](https://vedika.io/docs) | Y | GenAI-powered Vedic astrology API. Natural language queries for birth charts, compatibility analysis, and predictions |
+| [cv.cm](https://cv.cm/v) | [Link](https://cv.cm/api) | Y | Open API for AI video & image generation (Seedance, gpt-image-2, Seedream) with free credits for new users; callable from Claude/ChatGPT/Codex. |
 
 ## AI Gateway/Aggregator
 


### PR DESCRIPTION
Adds **cv.cm** to the GenAI APIs table.

cv.cm offers an open API for AI video and image generation (Seedance 2.0, gpt-image-2, Seedream), with free credits for new users and token auth — squarely in scope for this list. Callable from Claude, ChatGPT, Codex, etc.