### PR TITLE
Add Prismix — free AI status REST API (75+ services, no auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can start contributing by adding the following:
 | [Prompeteer.ai](https://prompeteer.ai) | [Link](https://prompeteer.ai/connect) | REST API to generate, score, and optimize AI prompts for 140+ platforms. Features Prompt Score quality analysis across 16 dimensions and PromptDrive auto-save cloud library |
 | [Arch Tools](https://archtools.dev/) | [Link](https://archtools.dev/docs) | The first x402 API hub — 58+ AI tools for search, scraping, analysis, and generation with native Coinbase x402 crypto payments on 15+ chains. MCP compatible |
 | [BGPT](https://bgpt.pro) | [Link](https://github.com/connerlambden/bgpt-mcp) | MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies |
+| [Prismix](https://prismix.dev) | [Link](https://prismix.dev/api/v1/statuses) | Free, no-auth REST API returning real-time uptime & incident status for 75+ AI services (OpenAI, Anthropic, Gemini, Mistral, etc.). CORS-enabled, no signup required. Also exposes AI news and MCP server directory at `/news` and `/mcp`. |
 
 ## GenAI API Integration Articles/Tutorials
 


### PR DESCRIPTION
## What this adds

Adds [Prismix](https://prismix.dev) to the **Other AI Tools** table.

Prismix provides a **free, no-auth, CORS-enabled REST API** that returns real-time uptime and incident status for 75+ AI services:

```
GET https://prismix.dev/api/v1/statuses
```

**Why it fits here:** Unlike other entries that are generative AI APIs, Prismix exposes *monitoring data about* generative AI providers — useful for developers who need to check API health before routing requests or building fallback logic.

**Additional endpoints:**
- `/news` — aggregated AI news from 70+ sources
- `/mcp` — directory of 500+ MCP servers

**Stack:** Cloudflare Workers + KV + Pages