### PR TITLE
docs: add Suede AI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
+| [Suede AI](https://suedeai.ai/) | [Link](https://app.suedeai.ai/openapi.json) | Rights-aware music/video/IP generation API with OpenAPI and x402 metadata for full-length music, video clips, rights lookup, and audio analysis. |
 
 ## Other AI Tools
 


### PR DESCRIPTION
Adds Suede AI to the AI Gateway/Aggregator table.

Prerequisite issue: #434 (assignment requested per `CONTRIBUTING.md`).

Live verification:
- https://suedeai.ai returns 200
- https://app.suedeai.ai/openapi.json currently exposes 3 paths
- https://app.suedeai.ai/.well-known/x402.json currently advertises 3 payable resources: music, video, and image generation
- https://app.suedeai.ai/.well-known/agent-card.json returns the Suede agent card

Validation:
- `git diff --check`
