### PR TITLE
Add MuAPI — OpenAI-compatible generative media aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
+| [MuAPI](https://muapi.ai) | [Link](https://api.muapi.ai/openapi.json) | OpenAI-compatible generative media API aggregating 44+ image, video, and audio models (Flux, Midjourney, Kling, Suno, and more) via a single unified endpoint. |
 
 ## Other AI Tools
 


### PR DESCRIPTION
## Summary

- [MuAPI](https://muapi.ai) is an OpenAI-compatible API aggregating 44+ generative media models across image, video, and audio generation.
- Single API key, single endpoint: `https://api.muapi.ai/v1`
- Supports standard OpenAI-compatible routes: `GET /v1/models` and `POST /v1/images/generations`
- Models include the Flux family, Midjourney, GPT-4o, Kling, HiDream, Seedream, Wan, Suno, and more.

## Changes

Added MuAPI to the **AI Gateway/Aggregator** table in `README.md`.

## Checklist

- [x] Entry follows existing table format (Project Homepage | Docs Link | Description)
- [x] Description is 2 lines or less
- [x] Link points to the live OpenAPI spec at `https://api.muapi.ai/openapi.json`