### PR TITLE
Add Tunova (hosted Suno music-generation API) to GenAI APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ You can start contributing by adding the following:
 | [HeyGen AI](https://www.heygen.com) | [Link](https://docs.heygen.com/reference/authentication-1) | Y | Heygen let's you create produce studio-quality videos with AI-generated avatars and voices. |
 | [DeepL Translate](https://www.deepl.com/translator) | [Link](https://developers.deepl.com/docs) | Y | DeepL provides high-quality text and document translations. | 
 | [IBM Watson AI](https://www.ibm.com/products/watsonx-ai) | [Link](https://cloud.ibm.com/developer/watson/documentation) | Y | IBM Watson lets you incorporate AI capabilities like conversation, language analysis, STT & TTS into your applications. |
-| [Tunova](https://tunova.ai) | [Link](https://api.tunova.ai/docs) | Y | Hosted Suno API for full-song music generation — REST + a hosted MCP server, async signed webhooks, billed only on successful renders (failed generations auto-refund). |
 | [Writer](https://writer.com/) | [Link](https://dev.writer.com/api-reference/list-models) | Y | Writer provides APIs for generating, enhancing, and personalizing content. |
 | [Together AI](https://www.together.ai/) | [Link](https://docs.together.ai/docs/quickstart) | Y | Together AI offers an API to query 50+ leading open-source models in a couple lines of code. |
 | [GooseAI](https://goose.ai/) | [Link](https://goose.ai/docs) | Y | GooseAI provides a fully managed NLP-as-a-Service, offering various GPT-based models with high customization and speed. |
@@ -69,6 +68,7 @@ You can start contributing by adding the following:
 | [SharpAPI](https://sharpapi.com/) | [Link](https://sharpapi.com/documentation) | Y | Generative AI APIs for some use cases in E-Commerce, Marketing, Content Management, HR Tech, Travel, etc.|
 | [Pollinations.AI](https://pollinations.ai/) | [Link](https://github.com/pollinations/pollinations/blob/master/APIDOCS.md) | N | Pollinations.AI provides free, no-signup APIs for text, image, and audio generation with no API keys required. |
 | [Vedika](https://vedika.io) | [Link](https://vedika.io/docs) | Y | GenAI-powered Vedic astrology API. Natural language queries for birth charts, compatibility analysis, and predictions |
+| [Tunova](https://tunova.ai) | [Link](https://api.tunova.ai/docs) | Y | Hosted Suno API for full-song music generation — REST + a hosted MCP server, async signed webhooks, billed only on successful renders (failed generations auto-refund) |
 
 ## AI Gateway/Aggregator
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You can start contributing by adding the following:
 | [HeyGen AI](https://www.heygen.com) | [Link](https://docs.heygen.com/reference/authentication-1) | Y | Heygen let's you create produce studio-quality videos with AI-generated avatars and voices. |
 | [DeepL Translate](https://www.deepl.com/translator) | [Link](https://developers.deepl.com/docs) | Y | DeepL provides high-quality text and document translations. | 
 | [IBM Watson AI](https://www.ibm.com/products/watsonx-ai) | [Link](https://cloud.ibm.com/developer/watson/documentation) | Y | IBM Watson lets you incorporate AI capabilities like conversation, language analysis, STT & TTS into your applications. |
+| [Tunova](https://tunova.ai) | [Link](https://api.tunova.ai/docs) | Y | Hosted Suno API for full-song music generation — REST + a hosted MCP server, async signed webhooks, billed only on successful renders (failed generations auto-refund). |
 | [Writer](https://writer.com/) | [Link](https://dev.writer.com/api-reference/list-models) | Y | Writer provides APIs for generating, enhancing, and personalizing content. |
 | [Together AI](https://www.together.ai/) | [Link](https://docs.together.ai/docs/quickstart) | Y | Together AI offers an API to query 50+ leading open-source models in a couple lines of code. |
 | [GooseAI](https://goose.ai/) | [Link](https://goose.ai/docs) | Y | GooseAI provides a fully managed NLP-as-a-Service, offering various GPT-based models with high customization and speed. |


### PR DESCRIPTION
Adds **Tunova** ([tunova.ai](https://tunova.ai)) to the *GenAI APIs* table — a hosted API for Suno full-song music generation (the table has voice/video/image/text APIs but no full-song music one yet).

- REST + a hosted **MCP server**; auth via `X-API-Key` (Y)
- Async with HMAC-signed webhooks; **billed only on successful renders** (failed generations auto-refund)
- Docs: https://api.tunova.ai/docs · SDKs: `pip install tunova` / `npm i tunova`

One table row, matching the existing 2-line-max format. Independent service, not affiliated with Suno.