### PR TITLE
Add RouterPlex to AI Gateway/Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
+| [RouterPlex](https://routerplex.com) | [Link](https://routerplex.com/docs) | OpenAI-compatible AI gateway — one API key for 25+ models (Claude, GPT, Gemini, DeepSeek) across 11 providers. Pay per token, no subscription, $5 free credit on signup |
 
 ## Other AI Tools
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
-| [RouterPlex](https://routerplex.com) | [Link](https://routerplex.com/docs) | OpenAI-compatible AI gateway — one API key for 25+ models (Claude, GPT, Gemini, DeepSeek) across 11 providers. Pay per token, no subscription, $5 free credit on signup |
+| [RouterPlex](https://routerplex.com) | [Link](https://routerplex.com/docs) | OpenAI-compatible AI gateway — one API key for 25+ models (Claude, GPT, Gemini, DeepSeek) across 11 providers. Pay per token, no subscription, $5 free credit on signup — extra $25 credit for signing up with GitHub |
 
 ## Other AI Tools
 


### PR DESCRIPTION
Adds RouterPlex (https://routerplex.com) to the AI Gateway/Aggregator section.

RouterPlex is an OpenAI-compatible AI gateway — one API key for 25+ models (Claude, GPT, Gemini, DeepSeek, and more) across 11 providers. Pay per token with no subscription; new accounts get $5 in free credit, no card required.

Follows the existing table format. Related issue: #413