### PR TITLE
docs: add OraClaw API listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can start contributing by adding the following:
 | [Prompeteer.ai](https://prompeteer.ai) | [Link](https://prompeteer.ai/connect) | REST API to generate, score, and optimize AI prompts for 140+ platforms. Features Prompt Score quality analysis across 16 dimensions and PromptDrive auto-save cloud library |
 | [Arch Tools](https://archtools.dev/) | [Link](https://archtools.dev/docs) | The first x402 API hub — 58+ AI tools for search, scraping, analysis, and generation with native Coinbase x402 crypto payments on 15+ chains. MCP compatible |
 | [BGPT](https://bgpt.pro) | [Link](https://github.com/connerlambden/bgpt-mcp) | MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies |
+| [OraClaw](https://github.com/Whatsonyourmind/oraclaw) | [Link](https://github.com/Whatsonyourmind/oraclaw) | Decision intelligence API with 19 deterministic ML algorithms for bandits, optimization, forecasting, graph analysis, and simulation. |
 
 ## GenAI API Integration Articles/Tutorials
 


### PR DESCRIPTION
Closes #367

Adds OraClaw to the curated API list with a short description and links to the project and repository.

Validation:
- git diff --check
- Source-level README review

This PR was pushed only from the saurabhhhcodes account.