### PR TITLE
docs: add Starveri API listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
+| [Starveri](https://api.starveri.net/credits) | [Link](https://api.starveri.net/docs) | OpenAI-compatible GPT/Codex gateway with public model discovery, prepaid credits, and visible model pricing metadata. |
 
 ## Other AI Tools
 


### PR DESCRIPTION
Closes #396

Adds Starveri to the AI Gateway/Aggregator section with its docs link and a short description.

Validation:
- git diff --check
- Source-level README review

This PR was pushed only from the saurabhhhcodes account.