### PR TITLE
docs: add FerryAPI listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You can start contributing by adding the following:
 | [AI/ML API](https://aimlapi.com/) | [Link](https://docs.aimlapi.com/) | Y |  An API aggregator that provides access to 100+ AI models via a single API. |
 | [Wit.ai](https://wit.ai/) | [Link](https://wit.ai/docs/http/20240304/) | Y | Wit.ai provides APIs to build natural language experiences. |
 | [PlayHT](https://play.ht/) | [Link](https://docs.play.ht/reference/api-getting-started) | Y | Play.ht provides realistic text-to-speech voices and audio generation for various applications. |
+| [FerryAPI](https://www.ferryapi.io/) | [Link](https://www.ferryapi.io/docs) | Y | OpenAI-compatible AI API gateway for production apps, with prepaid usage-based billing, developer API key management, and lower-cost model access. |
 | [Chooch AI](https://www.chooch.com/) | [Link](https://www.chooch.com/api/) | Y | Detects, processes, and instantly analyzes visual elements in video streams. |
 | [Clipdrop](https://clipdrop.co/) | [Link](https://clipdrop.co/apis/docs) | Y |  ClipDrop offers APIs for image upscaling, background removal, and other image enhancement features. |
 | [Astria AI](https://www.astria.ai/) | [Link](https://docs.astria.ai/docs/api/overview/) | Y | Astria is an API for fine-tuning and customization of generative image models. |


### PR DESCRIPTION
Closes #393

Adds FerryAPI to the GenAI APIs section with its docs link and a concise description.

Validation:
- git diff --check
- Source-level README review

This PR was pushed only from the saurabhhhcodes account.