### PR TITLE
Add DaoXE multi-model multi-protocol AI API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can start contributing by adding the following:
 | [Glio](https://glio.io/) | [Link](https://glio.io/docs/api/) | Unified API for the most cost-effective access to 50+ SOTA models. Kling, NanoBanana, Sora2, Veo3, Suno, ElevenLabs and more |
 | [EvoLink](https://evolink.ai/) | [Link](https://evolink.ai/docs) | Unified AI API gateway for 40+ models including video generation (Seedance 2.0, Sora 2, Veo 3.1), image generation, LLMs, and AI music |
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
+| [DaoXE](https://daoxe.com) | [Link](https://github.com/seven7763/DaoXE-AI) | Multi-model multi-protocol AI API gateway: Chat Completions, Responses, Anthropic Messages, image-compatible endpoints |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
 


### PR DESCRIPTION
## Summary
- Add DaoXE under **AI Gateway/Aggregator**.
- Multi-model multi-protocol AI API gateway (Chat Completions, Responses, Anthropic Messages, image-compatible endpoints).
- Docs/examples: https://github.com/seven7763/DaoXE-AI
- Not available in mainland China.

## Disclosure
I am affiliated with DaoXE.