### PR TITLE
Add NovAI to AI Gateway/Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
+| [NovAI](https://aiapi-pro.com) | [Link](https://aiapi-pro.com/docs) | OpenAI-compatible gateway to Chinese frontier models (DeepSeek, Qwen, GLM, Kimi, MiniMax, Doubao, Hunyuan) plus image and video generation on one endpoint |
 
 ## Other AI Tools
 


### PR DESCRIPTION
Adds **NovAI** to the **AI Gateway/Aggregator** table, alongside Vercel AI Gateway, OmniRoute, EvoLink and others.

NovAI is an OpenAI-compatible API gateway focused on Chinese frontier models (DeepSeek, Qwen, GLM, Kimi, MiniMax, Doubao, Hunyuan) — text, image, and video generation behind one `/v1` endpoint. It fits this section's unified-API theme, with a regional angle none of the current entries cover.

**Disclosure:** I'm affiliated with NovAI (operator self-submission). It's a paid hosted service (like other hosted gateways in the table) with a small trial credit. Endpoint is live at `https://aiapi-pro.com/v1`; public model list at `GET /v1/models`; docs at `https://aiapi-pro.com/docs`. Happy to adjust wording.