### PR TITLE
Add Lumify to Other AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can start contributing by adding the following:
 | [Prompeteer.ai](https://prompeteer.ai) | [Link](https://prompeteer.ai/connect) | REST API to generate, score, and optimize AI prompts for 140+ platforms. Features Prompt Score quality analysis across 16 dimensions and PromptDrive auto-save cloud library |
 | [Arch Tools](https://archtools.dev/) | [Link](https://archtools.dev/docs) | The first x402 API hub — 58+ AI tools for search, scraping, analysis, and generation with native Coinbase x402 crypto payments on 15+ chains. MCP compatible |
 | [BGPT](https://bgpt.pro) | [Link](https://github.com/connerlambden/bgpt-mcp) | MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies |
+| [Lumify](https://lumify.ai) | [Link](https://lumify.ai/docs/reference) | Agent-ready sports intelligence API and MCP server providing real-time schedules, live scores, odds, line movement, betting splits, and explainable AI bet confidence across MLB, NFL, NBA, NHL, tennis, soccer, and more |
 
 ## GenAI API Integration Articles/Tutorials
 


### PR DESCRIPTION
Closes #431

## What

Adds [Lumify](https://lumify.ai) to the **Other AI Tools** table (same category as BGPT / Arch Tools — MCP-compatible data/tooling APIs rather than a generative model).

Lumify is an agent-ready sports intelligence API and MCP server (`https://lumify.ai/mcp`): real-time schedules, live scores, odds, line movement, public betting splits, and explainable AI bet confidence across MLB, NFL, NCAAF, NCAAB, NBA, NHL, tennis, and soccer. Free tier available, no card required.

## Checklist

- [x] One-line addition to the `Other AI Tools` table in `README.md`
- [x] No other files/sections modified
- [x] Linked issue #431 opened per CONTRIBUTING.md

Made with [Cursor](https://cursor.com)