### PR TITLE
Add LLM Latency Tracker to Other AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can start contributing by adding the following:
 | [Prompeteer.ai](https://prompeteer.ai) | [Link](https://prompeteer.ai/connect) | REST API to generate, score, and optimize AI prompts for 140+ platforms. Features Prompt Score quality analysis across 16 dimensions and PromptDrive auto-save cloud library |
 | [Arch Tools](https://archtools.dev/) | [Link](https://archtools.dev/docs) | The first x402 API hub — 58+ AI tools for search, scraping, analysis, and generation with native Coinbase x402 crypto payments on 15+ chains. MCP compatible |
 | [BGPT](https://bgpt.pro) | [Link](https://github.com/connerlambden/bgpt-mcp) | MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies |
+| [LLM Latency Tracker](https://llmlatency.dev) | [Link](https://github.com/mazamaka/llm-latency-tracker) | Measured latency (TTFB, plus real time-to-first-token) and uptime for ~45 AI inference APIs from 4 regions, updated continuously. Free JSON API, MCP server, model deprecation calendar; data CC-BY-4.0 |
 
 ## GenAI API Integration Articles/Tutorials
 


### PR DESCRIPTION
Closes #436

Adds **LLM Latency Tracker** to the *Other AI Tools* table, in the existing format.

- **Homepage:** https://llmlatency.dev
- **Docs/repo:** https://github.com/mazamaka/llm-latency-tracker
- **JSON API:** https://llmlatency.dev/api/rankings.json (no key, no signup) · OpenAPI at `/openapi.json`
- **MCP server:** https://llmlatency.dev/mcp (Streamable HTTP, `get_ai_api_latency`)

Independent, provider-neutral latency and uptime for ~45 AI inference APIs, measured continuously from Germany, US Central, Tokyo and São Paulo. Edge latency (TTFB) is measured for every provider; real time-to-first-token is measured where an API key exists, and the two are never averaged together — the model name is printed next to every TTFT figure, since model size drives first-token time more than the API does.

Data is CC-BY-4.0 and the measurement code is open, so the methodology can be verified rather than taken on trust.

Single-line change, no other files touched.