### PR TITLE
Add UnificAlly to AI Gateway/Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
+| [UnificAlly](https://unifically.com) | [Link](https://docs.unifically.com) | One API for 100+ AI video, image, music, and speech models (Veo 3.1, Kling, SeeDance, Nano Banana, Suno, ElevenLabs). |
 
 ## Other AI Tools
 


### PR DESCRIPTION
Closes #438

Adds UnificAlly to the AI Gateway/Aggregator section.

- Homepage: https://unifically.com
- Docs: https://docs.unifically.com
- One API for 100+ AI video, image, music, and speech models (Veo 3.1, Kling, SeeDance, Nano Banana, Suno, ElevenLabs)

Disclosure: I work on UnificAlly.