### PR TITLE
Add XiuRouter to AI Gateway/Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can start contributing by adding the following:
 | [deAPI.ai](https://deapi.ai/) | [Link](https://docs.deapi.ai/) | Unified AI inference API on decentralized GPU infrastructure — image generation (Flux), TTS, transcription (Whisper), video generation, OCR, upscaling, background removal, and embeddings |
 | [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api) | [Link](https://agent-gateway-kappa.vercel.app/v1/agent-llm/docs) | Unified LLM gateway — route to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through one OpenAI-compatible API. BYOK, response caching, auto retries. 24+ models |
 | [PixelAPI](https://pixelapi.dev) | [Link](https://pixelapi.dev/docs) | Pay-per-use AI image API offering SDXL, FLUX image generation, background removal, and 4x upscaling. Python and JS SDKs available. |
+| [XiuRouter](https://router.xiu.ai/) | [Link](https://docs.xiu.ai/router/) | Hosted multi-model API with OpenAI Responses and Chat Completions, Anthropic Messages, Gemini GenerateContent, scoped API keys, usage-based pricing, and request-level usage and cost records. |
 
 ## Other AI Tools
 


### PR DESCRIPTION
Closes #446

## Summary

- Add XiuRouter to the existing **AI Gateway/Aggregator** table.
- Link directly to the XiuRouter product and Router documentation.
- Keep the change to one factual README row.

## Disclosure

I build XiuAI and XiuRouter, so this is a first-party submission on behalf of XiuLab Inc.

## Verification

- `https://router.xiu.ai/` returns HTTP 200.
- `https://docs.xiu.ai/router/` returns HTTP 200.
- `git diff --check` passes.
- The entry does not claim a free plan, automatic fallback, a fixed model count, or a universal savings percentage.
