### PR TITLE
Add ModelRush to AI Gateway/Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ You can start contributing by adding the following:
 | [Magic Hour](https://magichour.ai/) | [Link](https://docs.magichour.ai) | Y | Magic Hour offers a single API for AI video (Sora 2, Veo 3.1, Kling 3.0, Seedance, WAN) and image generation (GPT-image, Nano Banana Pro, Flux), plus face swap, lip sync and talking photo |
 | [TeamoRouter](https://teamorouter.cn) | [Link](https://teamorouter.cn/docs) | LLM API gateway with OpenAI-compatible endpoints plus a native Anthropic Messages API — Claude Code and Codex connect by changing only the base URL |
 | [Bifrost](https://www.getmaxim.ai/bifrost) | [Link](https://docs.getbifrost.ai/) | Go-native, OpenAI-compatible AI gateway with multi-provider routing, automatic failover, load balancing, guardrails, MCP gateway support, and built-in logs, metrics, and tracing |
+| [ModelRush](https://modelrush.ai) | [Link](https://modelrush.ai/docs) | OpenAI-compatible API platform for text, image, video, and voice models, with public model discovery, regional routing, and request-level observability. |
 
 ## Other AI Tools
 


### PR DESCRIPTION
## Summary

Add ModelRush to the existing **AI Gateway/Aggregator** table with its homepage, API documentation, and a short factual description. This changes one README row only.

Closes #453.

Following [the maintainer's invitation to raise a PR](https://github.com/foss42/awesome-generative-ai-apis/issues/453#issuecomment-5554453064).

## Validation

- Checked that ModelRush is not already listed.
- Matched the section's three-column table format.
- Confirmed the homepage and documentation return HTTP 200.
- `git diff --check` passes.

Affiliation disclosure: I work on ModelRush. Public examples and compatibility tooling are available at https://github.com/Moonveil-AI/modelrush-developer-tools.
